### PR TITLE
remove svc.cluster.local from serverAddress

### DIFF
--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -43,7 +43,6 @@ const (
 	minioCtrName             = "minio"
 	minioLabel               = "minio"
 	minioPVCName             = "minio-pvc"
-	minioServerSuffixFmt     = "%s.svc.cluster.local"
 	minioVolumeName          = "data"
 	objectStoreDataDir       = "/data"
 )
@@ -112,7 +111,7 @@ func (c *MinioController) makeMinioHeadlessService(name, namespace string, spec 
 func (c *MinioController) buildMinioCtrArgs(statefulSetPrefix, headlessServiceName, namespace string, serverCount int32) []string {
 	args := []string{"server"}
 	for i := int32(0); i < serverCount; i++ {
-		serverAddress := fmt.Sprintf("http://%s-%d.%s.%s%s", statefulSetPrefix, i, headlessServiceName, fmt.Sprintf(minioServerSuffixFmt, namespace), objectStoreDataDir)
+		serverAddress := fmt.Sprintf("http://%s-%d.%s.%s%s", statefulSetPrefix, i, headlessServiceName, namespace, objectStoreDataDir)
 		args = append(args, serverAddress)
 	}
 


### PR DESCRIPTION
Services in kubernetes can be reached at <servicename>.<namespace> without specifying svc.cluster.local. Removing this resolves issues with deployments where the kubernetes domain has been changed from the default.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
